### PR TITLE
chore(eks): add additional iam roles on for aws-auth configmap

### DIFF
--- a/tg-modules/eks/terragrunt.hcl
+++ b/tg-modules/eks/terragrunt.hcl
@@ -113,7 +113,7 @@ module "eks_cluster_${eks_region_k}_${eks_name}" {
   %{ if get_env("AWS_ASSUMED_ROLE", "") != "" }
   kube_exec_auth_role_arn = "${ get_env("AWS_ASSUMED_ROLE", "") }"
   kube_exec_auth_role_arn_enabled = true
-  kubernetes_config_map_ignore_role_changes = 0
+  kubernetes_config_map_ignore_role_changes = false
   %{ endif ~}
 
 }

--- a/tg-modules/eks/terragrunt.hcl
+++ b/tg-modules/eks/terragrunt.hcl
@@ -113,6 +113,7 @@ module "eks_cluster_${eks_region_k}_${eks_name}" {
   %{ if get_env("AWS_ASSUMED_ROLE", "") != "" }
   kube_exec_auth_role_arn = "${ get_env("AWS_ASSUMED_ROLE", "") }"
   kube_exec_auth_role_arn_enabled = true
+  kubernetes_config_map_ignore_role_changes = 0
   %{ endif ~}
 
 }

--- a/tg-modules/eks/terragrunt.hcl
+++ b/tg-modules/eks/terragrunt.hcl
@@ -111,7 +111,7 @@ module "eks_cluster_${eks_region_k}_${eks_name}" {
   ]
 
   %{ if get_env("AWS_ASSUMED_ROLE", "") != "" }
-  kube_exec_auth_role_arn = get_env("AWS_ASSUMED_ROLE", "")
+  kube_exec_auth_role_arn = "${ get_env("AWS_ASSUMED_ROLE", "") }"
   kube_exec_auth_role_arn_enabled = true
   %{ endif ~}
 

--- a/tg-modules/eks/terragrunt.hcl
+++ b/tg-modules/eks/terragrunt.hcl
@@ -111,8 +111,6 @@ module "eks_cluster_${eks_region_k}_${eks_name}" {
   ]
 
   %{ if get_env("AWS_ASSUMED_ROLE", "") != "" }
-  kube_exec_auth_role_arn = "${ get_env("AWS_ASSUMED_ROLE", "") }"
-  kube_exec_auth_role_arn_enabled = true
   kube_data_auth_enabled = true
   %{ endif ~}
 

--- a/tg-modules/eks/terragrunt.hcl
+++ b/tg-modules/eks/terragrunt.hcl
@@ -151,6 +151,12 @@ module "eks_node_group_sg_${eks_region_k}_${eks_name}_${eng_name}" {
     %{ endfor ~}
   ]
 
+  %{ if get_env("AWS_ASSUMED_ROLE", "") != "" }
+  kube_exec_auth_role_arn = get_env("AWS_ASSUMED_ROLE", "")
+  kube_exec_auth_role_arn_enabled = true
+  %{ endif ~}
+  
+
 }
 
      %{ endif ~}

--- a/tg-modules/eks/terragrunt.hcl
+++ b/tg-modules/eks/terragrunt.hcl
@@ -110,6 +110,11 @@ module "eks_cluster_${eks_region_k}_${eks_name}" {
 
   ]
 
+  %{ if get_env("AWS_ASSUMED_ROLE", "") != "" }
+  kube_exec_auth_role_arn = get_env("AWS_ASSUMED_ROLE", "")
+  kube_exec_auth_role_arn_enabled = true
+  %{ endif ~}
+
 }
 
 resource "aws_iam_role_policy_attachment" "alb_policy_${eks_region_k}_${eks_name}" {
@@ -149,13 +154,7 @@ module "eks_node_group_sg_${eks_region_k}_${eks_name}_${eng_name}" {
       cidr_blocks = [ %{ for cidr_filter in sg_rule_values.cidr-filters ~} "${cidr_filter}", %{ endfor ~} ]
     },
     %{ endfor ~}
-  ]
-
-  %{ if get_env("AWS_ASSUMED_ROLE", "") != "" }
-  kube_exec_auth_role_arn = get_env("AWS_ASSUMED_ROLE", "")
-  kube_exec_auth_role_arn_enabled = true
-  %{ endif ~}
-  
+  ] 
 
 }
 

--- a/tg-modules/eks/terragrunt.hcl
+++ b/tg-modules/eks/terragrunt.hcl
@@ -113,7 +113,7 @@ module "eks_cluster_${eks_region_k}_${eks_name}" {
   %{ if get_env("AWS_ASSUMED_ROLE", "") != "" }
   kube_exec_auth_role_arn = "${ get_env("AWS_ASSUMED_ROLE", "") }"
   kube_exec_auth_role_arn_enabled = true
-  kubernetes_config_map_ignore_role_changes = false
+  kube_data_auth_enabled = true
   %{ endif ~}
 
 }


### PR DESCRIPTION
It's not possible to do so afterwards (well, it is, but doing some tfstate surgery). Workaround is to `kubectl edit cm -n kube-system aws-auth` and manually add there the corresponding role.