### PR TITLE
feat(eks-alb)!: make alb configurable via cluster_name.alb key

### DIFF
--- a/tg-modules/eks-alb/terragrunt.hcl
+++ b/tg-modules/eks-alb/terragrunt.hcl
@@ -145,13 +145,14 @@ module "alb_${eks_region_k}_${eks_name}" {
     %{ endfor ~}
   ] )
   tags                      = {}
-  node_port                 = 30443
-  node_port_protocol        = "HTTPS"
-  enable_http               = true
-  enable_https              = true
-  http_redirect             = true
+  node_port                 = ${ chomp(try(eks_values.alb.node-port, 30443)) }
+  node_port_protocol        = "${ chomp(try(eks_values.alb.node-port-protocol, "HTTPS")) }"
+  node_port_protocol_version = "${ chomp(try(eks_values.alb.node-port-protocol-version, "HTTP1")) }"
+  enable_http               = ${ chomp(try(eks_values.alb.enable-http, true)) }
+  enable_https              = ${ chomp(try(eks_values.alb.enable-https, true)) }
+  http_redirect             = ${ chomp(try(eks_values.alb.http-redirect, true)) }
   certificate_arn           = module.acm_request_certificate_${eks_region_k}_${eks_name}.arn
-  internal                  = false
+  internal                  = ${ chomp(try(eks_values.alb.internal, false)) }
 
 }
 

--- a/tg-modules/eks-alb/tf-module/alb.tf
+++ b/tg-modules/eks-alb/tf-module/alb.tf
@@ -24,6 +24,7 @@ resource "aws_alb_target_group" "main" {
   name_prefix = local.alb_name_prefix
   port        = var.node_port
   protocol    = var.node_port_protocol
+  protocol_version = var.node_port_protocol_version
   target_type = var.target_type
   vpc_id      = var.vpcid
 

--- a/tg-modules/eks-alb/tf-module/variables.tf
+++ b/tg-modules/eks-alb/tf-module/variables.tf
@@ -98,6 +98,11 @@ variable "node_port_protocol" {
   description = "NodePort protocol value"
 }
 
+variable "node_port_protocol_version" {
+  default     = "HTTP1"
+  description = "NodePort protocol version value"
+}
+
 variable "certificate_arn" {
   default     = ""
   description = "Required if https is enabled"

--- a/tg-modules/route53/terragrunt.hcl
+++ b/tg-modules/route53/terragrunt.hcl
@@ -59,7 +59,7 @@ resource "aws_route53_record" "eks_${eks_region_k}_${eks_name}" {
   records = [try(jsondecode(var.eks_alb_json).eks_alb_${eks_region_k}_${eks_name}.alb_info.dns_name, "known-after-apply")]
 }
 
-      %{ for hostname in try(eks_values.alb-dns-aliases, [] ) ~}
+      %{ for hostname in try(eks_values.alb.dns-aliases, [] ) ~}
 
 resource "aws_route53_record" "eks_${eks_region_k}_${eks_name}_${ replace("${hostname}", ".", "_")}" {
   zone_id = data.aws_route53_zone.service_zone.zone_id


### PR DESCRIPTION
[This](https://github.com/cardano-foundation/terragrunt-aws-eks/compare/feat/make-eks-alb-more-configurable?expand=1#diff-2f0affdcb1878070f85a41673d3fd5a05ee6d147f981741c551c64fd44ea9ec0L62) makes it breaking, as it requires a small change in `config.yaml` :)