### PR TITLE
feat(eks): add support to override max-pods restrictions set by aws

### DIFF
--- a/environments/dev-example/config.yaml
+++ b/environments/dev-example/config.yaml
@@ -28,10 +28,17 @@ default-eks-addons: &default-eks-addons
   coredns:
     addon-version: v1.11.4-eksbuild.2
     resolve-conflicts: "OVERWRITE"
+  vpc-cni:
+    addon-version: v1.20.4-eksbuild.2
+    resolve-conflicts: "OVERWRITE"
+    env:
+      ENABLE_PREFIX_DELEGATION: "true"
 
 # key here is a mere human-readable description/tag
 default-iam-policies: &default-iam-policies
   enable-ebs-creation: "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+  enable-efs-creation: "arn:aws:iam::aws:policy/service-role/AmazonEFSCSIDriverPolicy"
+  enable-ssm-access: "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 
 alb-dns-aliases: &default-alb-dns-aliases
   - api
@@ -77,6 +84,8 @@ eks:
             desired-size: 1
             min-size: 1
             max-size: 3
+            # NOTE: 110 is kubernetes' default, in aws, we require ENABLE_PREFIX_DELEGATION=true for vpc-cni addon
+            # max-pods: 110
             block-device-mappings:
               xvda:
                 volume-size: 40 # gbs


### PR DESCRIPTION
This is only compatible with Amazon Linux 2023, AL2 uses a different way to setup kubelet environment.

`vpc-cni`'s `ENABLE_PREFIX_DELEGATION` makes the addon to, instead of assigning a single IP address from the subnet to a pod, Prefix Delegation assigns an entire CIDR block (a 2$/28$ prefix, which provides 16 IP addresses) to each ENI attached to the node, maximizing the amount of pods that can be scheduled to an instance.
Still, you might want to manually increase the limit for smaller instances, for example, IPs were not limiting a `t3.small` to 8 pods, it was something else (I couldn't find what on AL2023, [this is for AL2](https://github.com/awslabs/amazon-eks-ami/blob/main/templates/al2/runtime/max-pods-calculator.sh)), so I just came up with the ssm workaround to explicitly set kubelet's `--max-pods`.