### PR TITLE
feat(eks-helm-bootstrap): support VolumeSnapshots

### DIFF
--- a/environments/dev-example/config.yaml
+++ b/environments/dev-example/config.yaml
@@ -57,6 +57,8 @@ eks:
         k8s-version: 1.30
         public-access-cidrs: # this is used for kube api
           <<: *default-eks-public-access-cidrs
+        resourceQuotas:
+          countVolumeSnapshots: 50
         network:
           vpc: example-com
           allowed-cidr-blocks: # this is used for an special sg which allow full access to all the ports

--- a/tg-modules/eks-helm-bootstrap/terragrunt.hcl
+++ b/tg-modules/eks-helm-bootstrap/terragrunt.hcl
@@ -136,7 +136,7 @@ data "template_file" "${eks_region_k}_${eks_name}_ebs_csi_aws_vsc_manifest" {
 apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
-  name: csi-aws-vsc
+  name: ebs-csi-aws
 driver: ebs.csi.aws.com
 deletionPolicy: Delete
 EOT
@@ -146,6 +146,25 @@ resource "kubernetes_manifest" "${eks_region_k}_${eks_name}_ebs_csi_aws_vsc" {
   provider = kubernetes.${eks_region_k}_${eks_name}
   manifest = yamldecode(data.template_file.${eks_region_k}_${eks_name}_ebs_csi_aws_vsc_manifest.rendered)
 }
+
+data "template_file" "${eks_region_k}_${eks_name}_snapshot_quota_manifest" {
+  template = <<EOT
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: snapshots
+  namespace: default
+spec:
+  hard:
+    count/volumesnapshots.snapshot.storage.k8s.io: "${ try(eks_values.resourceQuotas.countVolumeSnapshots, "50")}"
+EOT
+}
+
+resource "kubernetes_manifest" "${eks_region_k}_${eks_name}_snapshot_quota" {
+  provider = kubernetes.${eks_region_k}_${eks_name}
+  manifest = yamldecode(data.template_file.${eks_region_k}_${eks_name}_snapshot_quota_manifest.rendered)
+}
+    
 %{ endif }
 
 resource "kubernetes_annotations" "${eks_region_k}_${eks_name}_gp2_disable_default" {

--- a/tg-modules/eks-helm-bootstrap/terragrunt.hcl
+++ b/tg-modules/eks-helm-bootstrap/terragrunt.hcl
@@ -130,6 +130,24 @@ resource "kubernetes_manifest" "${eks_region_k}_${eks_name}_gp3_encrypted_csi" {
   manifest = yamldecode(data.template_file.${eks_region_k}_${eks_name}_gp3_encrypted_csi_manifest.rendered)
 }
 
+%{ if contains(keys(eks_values.addons), "snapshot-controller") }
+data "template_file" "${eks_region_k}_${eks_name}_ebs_csi_aws_vsc_manifest" {
+  template = <<EOT
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-aws-vsc
+driver: ebs.csi.aws.com
+deletionPolicy: Delete
+EOT
+}
+
+resource "kubernetes_manifest" "${eks_region_k}_${eks_name}_ebs_csi_aws_vsc" {
+  provider = kubernetes.${eks_region_k}_${eks_name}
+  manifest = yamldecode(data.template_file.${eks_region_k}_${eks_name}_ebs_csi_aws_vsc_manifest.rendered)
+}
+%{ endif }
+
 resource "kubernetes_annotations" "${eks_region_k}_${eks_name}_gp2_disable_default" {
 
   force = true

--- a/tg-modules/eks-helm-bootstrap/terragrunt.hcl
+++ b/tg-modules/eks-helm-bootstrap/terragrunt.hcl
@@ -156,7 +156,7 @@ metadata:
   namespace: default
 spec:
   hard:
-    count/volumesnapshots.snapshot.storage.k8s.io: "${ try(eks_values.resourceQuotas.countVolumeSnapshots, "50")}"
+    count/volumesnapshots.snapshot.storage.k8s.io: "${ try(eks_values.resourceQuotas.countVolumeSnapshots, 50)}"
 EOT
 }
 

--- a/tg-modules/eks-helm-bootstrap/terragrunt.hcl
+++ b/tg-modules/eks-helm-bootstrap/terragrunt.hcl
@@ -70,8 +70,6 @@ data "template_file" "${eks_region_k}_${eks_name}_gp3_encrypted_manifest" {
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
   name: gp3-encrypted
 parameters:
   type: gp3
@@ -99,6 +97,24 @@ allowVolumeExpansion: true
 EOT
 }
 
+data "template_file" "${eks_region_k}_${eks_name}_gp3_encrypted_csi_manifest" {
+  template = <<EOT
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  name: gp3-encrypted-csi
+parameters:
+  type: gp3
+  encrypted: "true"
+provisioner: ebs.csi.aws.com
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+EOT
+}
+
 resource "kubernetes_manifest" "${eks_region_k}_${eks_name}_gp3" {
   provider = kubernetes.${eks_region_k}_${eks_name}
   manifest = yamldecode(data.template_file.${eks_region_k}_${eks_name}_gp3_manifest.rendered)
@@ -107,6 +123,11 @@ resource "kubernetes_manifest" "${eks_region_k}_${eks_name}_gp3" {
 resource "kubernetes_manifest" "${eks_region_k}_${eks_name}_gp3_encrypted" {
   provider = kubernetes.${eks_region_k}_${eks_name}
   manifest = yamldecode(data.template_file.${eks_region_k}_${eks_name}_gp3_encrypted_manifest.rendered)
+}
+
+resource "kubernetes_manifest" "${eks_region_k}_${eks_name}_gp3_encrypted_csi" {
+  provider = kubernetes.${eks_region_k}_${eks_name}
+  manifest = yamldecode(data.template_file.${eks_region_k}_${eks_name}_gp3_encrypted_csi_manifest.rendered)
 }
 
 resource "kubernetes_annotations" "${eks_region_k}_${eks_name}_gp2_disable_default" {


### PR DESCRIPTION
Using provisioner ebs.csi.aws.com. This is the newer provisioner for the aws-ebs-csi-driver and required for creating VolumeSnapshots.  
Config is not changing in a breaking way but there is a new default `StorageClass`. This shouldn't break existing deployments since it only applies to new `PVCs`. 